### PR TITLE
Fix Issue #3: Add Support for Identifying Identical Table Names Across Different Data Sets

### DIFF
--- a/definitions/example.js
+++ b/definitions/example.js
@@ -24,8 +24,11 @@ const commonAssertionsResult = commonAssertions({
     }
   },
   uniqueKeyConditions: {
-    "first_table": ["id"],
-    "second_table": ["id", "updated_date"]
+    // Format: "schema": { "table": [column1, column2, ...], ... }
+    "dataform": {
+      "first_table": ["id"],
+      "second_table": ["id", "updated_date"]
+    }
   },
   dataFreshnessConditions: {
     // Format: "schema": { "table": { "dateColumn", "timeUnit", "delayCondition" }, ... }

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -59,17 +59,22 @@ const commonAssertionsResult = commonAssertions({
     }
   },
   referentialIntegrityConditions: {
-    "first_table": [{
-        "parentKey": "id",
-        "childTable": "second_table",
-        "childKey": "id"
-      },
-      {
-        "parentKey": "id",
-        "childTable": "third_table",
-        "childKey": "parent_id"
-      }
-    ]
+    // Format: "parentSchema": { "parentTable": [{ parentKey, childSchema, childTable, childKey }, ...], ... }
+    "dataform": {
+      "first_table": [{
+          "parentKey": "id",
+          "childSchema": "dataform",
+          "childTable": "second_table",
+          "childKey": "id"
+        },
+        {
+          "parentKey": "id",
+          "childSchema": "dataform",
+          "childTable": "third_table",
+          "childKey": "parent_id"
+        }
+      ]
+    }
   }
 });
 

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -37,13 +37,16 @@ const commonAssertionsResult = commonAssertions({
     }
   },
   dataCompletenessConditions: {
-    "first_table": {
-      // Format: "column": allowedPercentageNull
-      "updated_date": 1, // 1% of null values allowed in the updated_date column
-      "id": 20
-    },
-    "second_table": {
-      "id": 30
+    // Format: "schema": { "table": { "column": allowedPercentageNull, ... }, ... }
+    "dataform": {
+      "first_table": {
+        // Format: "column": allowedPercentageNull
+        "updated_date": 1, // 1% of null values allowed in the updated_date column
+        "id": 20
+      },
+      "second_table": {
+        "id": 30
+      }
     }
   },
   referentialIntegrityConditions: {

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -12,13 +12,15 @@ const commonAssertionsResult = commonAssertions({
     // "disabledInEnvs": ["dv", "qa"]
   },
   rowConditions: {
-    "first_table": {
-      "id_not_null": "id IS NOT NULL",
-      "id_strict_positive": "id > 0"
-    },
-    "second_table": {
-      "id_in_accepted_values": "id IN (1, 2, 3)"
-    }
+    // Format: "schema": { "table": { "conditionName": "conditionQuery", ... }, ... }
+    "dataform": {
+      "first_table": {
+        "id_not_null": "id IS NOT NULL",
+        "id_strict_positive": "id > 0"
+      },
+      "second_table": {
+        "id_in_accepted_values": "id IN (1, 2, 3)"
+      }
   },
   uniqueKeyConditions: {
     "first_table": ["id"],

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -32,7 +32,7 @@ const commonAssertionsResult = commonAssertions({
   },
   dataFreshnessConditions: {
     // Format: "schema": { "table": { "dateColumn", "timeUnit", "delayCondition" }, ... }
-    "dataform" : {
+    "dataform": {
       "first_table": {
         "dateColumn": "updated_date",
         "timeUnit": "DAY",

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -25,15 +25,18 @@ const commonAssertionsResult = commonAssertions({
     "second_table": ["id", "updated_date"]
   },
   dataFreshnessConditions: {
-    "first_table": {
-      "dateColumn": "updated_date",
-      "timeUnit": "DAY",
-      "delayCondition": 1,
-    },
-    "second_table": {
-      "dateColumn": "updated_date",
-      "timeUnit": "MONTH",
-      "delayCondition": 3,
+    // Format: "schema": { "table": { "dateColumn", "timeUnit", "delayCondition" }, ... }
+    "dataform" : {
+      "first_table": {
+        "dateColumn": "updated_date",
+        "timeUnit": "DAY",
+        "delayCondition": 1,
+      },
+      "second_table": {
+        "dateColumn": "updated_date",
+        "timeUnit": "MONTH",
+        "delayCondition": 3,
+      }
     }
   },
   dataCompletenessConditions: {

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -21,6 +21,7 @@ const commonAssertionsResult = commonAssertions({
       "second_table": {
         "id_in_accepted_values": "id IN (1, 2, 3)"
       }
+    }
   },
   uniqueKeyConditions: {
     "first_table": ["id"],

--- a/includes/referential_integrity_assertions.js
+++ b/includes/referential_integrity_assertions.js
@@ -69,7 +69,7 @@ module.exports = (globalParams, config, referentialIntegrityConditions) => {
     for (let parentTable in parentTables) {
       const relationships = parentTables[parentTable];
       const parentFilter = config[parentTable]?.where ?? true;
-      
+
       relationships.forEach(({
         parentKey,
         childSchema,

--- a/includes/row_condition_assertions.js
+++ b/includes/row_condition_assertions.js
@@ -44,7 +44,13 @@ module.exports = (globalParams, rowConditions) => {
     for (let tableName in tableNames) {
       for (let conditionName in tableNames[tableName]) {
         const conditionQuery = tableNames[tableName][conditionName];
-        createRowConditionAssertion(globalParams, schemaName, tableName, conditionName, conditionQuery);
+        createRowConditionAssertion(
+          globalParams,
+          schemaName,
+          tableName,
+          conditionName,
+          conditionQuery
+        );
       }
     }
   }

--- a/includes/unique_key_assertions.js
+++ b/includes/unique_key_assertions.js
@@ -11,22 +11,23 @@
 
 /**
  * @param {Object} globalParams - See index.js for details.
+ * @param {string} schemaName - The name of the schema to check for unique keys.
  * @param {string} tableName - The name of the table to check for unique keys.
  * @param {Array} columns - An array of column names that should form a unique key.
  */
 
 const assertions = [];
 
-const createUniqueKeyAssertion = (globalParams, tableName, columns) => {
+const createUniqueKeyAssertion = (globalParams, schemaName, tableName, columns) => {
   const uniqueColumns = columns.join(', ');
 
-  const assertion = assert(`assert_unique_key_${tableName}`)
+  const assertion = assert(`assert_unique_key_${schemaName}_${tableName}`)
     .database(globalParams.database)
     .schema(globalParams.schema)
-    .description(`Check that values in columns (${uniqueColumns}) in ${tableName} form a unique key`)
+    .description(`Check that values in columns (${uniqueColumns}) in ${schemaName}.${tableName} form a unique key`)
     .tags("assert-unique-key")
     .query(ctx => `SELECT ${uniqueColumns}
-                       FROM ${ctx.ref(tableName)}
+                       FROM ${ctx.ref(schemaName, tableName)}
                        GROUP BY ${uniqueColumns}
                        HAVING COUNT(*) > 1`);
 
@@ -40,9 +41,12 @@ const createUniqueKeyAssertion = (globalParams, tableName, columns) => {
 module.exports = (globalParams, uniqueKeyConditions) => {
 
   // Loop through uniqueKeyConditions to create unique key check assertions.
-  for (let tableName in uniqueKeyConditions) {
-    const columns = uniqueKeyConditions[tableName];
-    createUniqueKeyAssertion(globalParams, tableName, columns);
+  for (let schemaName in uniqueKeyConditions) {
+    const tableNames = uniqueKeyConditions[schemaName];
+    for (let tableName in tableNames) {
+      const columns = tableNames[tableName];
+      createUniqueKeyAssertion(globalParams, schemaName, tableName, columns);
+    }
   }
 
   return assertions;


### PR DESCRIPTION
# What is this PR ?

This PR solve https://github.com/devoteamgcloud/dataform-assertions/issues/3

- https://github.com/devoteamgcloud/dataform-assertions/issues/3

# Overview

- Expanded example.js to accept schema.
- Expanded JavaScript in includes/assertions to accept schema.


# Information

## Context Method: `ref`

`ref` method use individual arguments for the "schema", and "name" values.

>References another action, adding it as a dependency to this action, returning valid SQL to be used in a from expression.
This function can be called with a Resolvable object, for example: ${ref({ name: "name", schema: "schema", database: "database" })}

> This function can also be called using individual arguments for the "database", "schema", and "name" values. When only two values are provided, the default database is used and the values are interpreted as "schema" and "name". When only one value is provided, the default database and schema are used, with the provided value interpreted as `"name"`. ${ref("database", "schema", "name")} ${ref("schema", "name")} ${ref("name")}

[document](https://cloud.google.com/dataform/docs/reference/dataform-core-reference#commoncontext)