### PR TITLE
specify a time zone in CURRENT_DATE() in data_freshness_assertion

### DIFF
--- a/definitions/example.js
+++ b/definitions/example.js
@@ -29,11 +29,14 @@ const commonAssertionsResult = commonAssertions({
       "dateColumn": "updated_date",
       "timeUnit": "DAY",
       "delayCondition": 1,
+      "timeZone": "America/Los_Angeles"
     },
     "second_table": {
       "dateColumn": "updated_date",
       "timeUnit": "MONTH",
       "delayCondition": 3,
+      "timeZone": "-08"
+
     }
   },
   dataCompletenessConditions: {

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -36,7 +36,6 @@ const commonAssertionsResult = commonAssertions({
       "timeUnit": "MONTH",
       "delayCondition": 3,
       "timeZone": "-08"
-
     }
   },
   dataCompletenessConditions: {

--- a/includes/data_freshness_assertions.js
+++ b/includes/data_freshness_assertions.js
@@ -17,7 +17,7 @@
 
 const assertions = [];
 
-const createDataFreshnessAssertion = (globalParams, tableName, delayCondition, timeUnit, dateColumn) => {
+const createDataFreshnessAssertion = (globalParams, tableName, delayCondition, timeUnit, dateColumn, timeZone = "UTC") => {
   const assertion = assert(`assert_freshness_${tableName}`)
     .database(globalParams.database)
     .schema(globalParams.schema)
@@ -27,7 +27,7 @@ const createDataFreshnessAssertion = (globalParams, tableName, delayCondition, t
                 WITH
                     freshness AS (
                         SELECT
-                            DATE_DIFF(CURRENT_DATE(), MAX(${dateColumn}), ${timeUnit}) AS delay
+                            DATE_DIFF(CURRENT_DATE("${timeZone}"), MAX(${dateColumn}), ${timeUnit}) AS delay
                         FROM
                             ${ctx.ref(tableName)}
                     )
@@ -53,9 +53,10 @@ module.exports = (globalParams, freshnessConditions) => {
     const {
       delayCondition,
       timeUnit,
-      dateColumn
+      dateColumn,
+      timeZone
     } = freshnessConditions[tableName];
-    createDataFreshnessAssertion(globalParams, tableName, delayCondition, timeUnit, dateColumn);
+    createDataFreshnessAssertion(globalParams, tableName, delayCondition, timeUnit, dateColumn, timeZone);
   }
 
   return assertions;


### PR DESCRIPTION
resolves #5 

## Overview

- add `timeZone` in `dataFreshnessConditions` to specify a time zone in `CURRENT_DATE`.
- since it is a default argument, it does not cause any breaking change.